### PR TITLE
Use CommonJS syntax instead of the experimental ES modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ coverage
 */testem.log
 */typings
 
+# Wombat-dressing-room
+.npmrc
+
 # System Files
 */.DS_Store
 */Thumbs.db

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cros-dpsl-js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cros-dpsl-js",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -1,17 +1,16 @@
 {
   "name": "cros-dpsl-js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Diagnostics processor support library for Chrome OS",
   "main": "./src/dpsl.js",
   "exports": "./src/dpsl.js",
-  "type": "module",
   "directories": {
     "doc": "docs"
   },
   "scripts": {
     "build": "node_modules/.bin/node src/dpsl.js",
     "lint": "node_modules/.bin/eslint .",
-    "test": "node_modules/.bin/node --experimental-vm-modules node_modules/.bin/jest --coverage",
+    "test": "node_modules/.bin/node node_modules/.bin/jest --coverage",
     "script:ci": "sh ./scripts/ci.sh",
     "script:cd": "sh ./scripts/cd.sh"
   },

--- a/src/__tests__/dpsl.test.js
+++ b/src/__tests__/dpsl.test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {dpsl} from '../dpsl.js';
+const {dpsl} = require('../dpsl.js');
 
 describe('dpsl.telemetry tests', () => {
   let originalChrome;

--- a/src/diagnostics_manager.js
+++ b/src/diagnostics_manager.js
@@ -34,7 +34,7 @@ const ROUTINE_COMMAND_TYPE = {
  * Keeps track of Routine status when running dpsl.diagnostics.* diagnostics
  * routines.
  */
-export class Routine {
+class Routine {
   /**
    * @param {!number} id
    */
@@ -185,7 +185,7 @@ class MemoryManager {
 /**
  * DPSL Diagnostics Manager for dpsl.diagnostics.* APIs.
  */
-export default class DPSLDiagnosticsManager {
+class DPSLDiagnosticsManager {
   /**
    * @constructor
    */
@@ -218,3 +218,8 @@ export default class DPSLDiagnosticsManager {
     return chrome.os.diagnostics.getAvailableRoutines();
   }
 }
+
+module.exports = {
+  DPSLDiagnosticsManager: DPSLDiagnosticsManager,
+  Routine: Routine,
+};

--- a/src/dpsl.js
+++ b/src/dpsl.js
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-import DPSLTelemetryRequester from './telemetry_requester.js';
-import DPSLDiagnosticsRequester from './diagnostics_manager.js';
+const {DPSLTelemetryRequester} = require('./telemetry_requester.js');
+const {DPSLDiagnosticsManager, Routine} = require('./diagnostics_manager.js');
 
 const dpsl = {
   telemetry: new DPSLTelemetryRequester(),
-  diagnostics: new DPSLDiagnosticsRequester(),
+  diagnostics: new DPSLDiagnosticsManager(),
 };
 
-export {Routine} from './diagnostics_manager.js';
-export {dpsl};
+module.exports = {
+  dpsl: dpsl,
+  Routine: Routine,
+};

--- a/src/telemetry_requester.js
+++ b/src/telemetry_requester.js
@@ -26,7 +26,7 @@
 /**
  * DPSL Telemetry Requester used in dpsl.telemetry.*.
  */
-export default class DPSLTelemetryRequester {
+class DPSLTelemetryRequester {
   /**
    * Requests CachedVpd info.
    * @return { !Promise<!dpsl.VpdInfo> }
@@ -45,3 +45,7 @@ export default class DPSLTelemetryRequester {
     return chrome.os.telemetry.getOemData();
   }
 }
+
+module.exports = {
+  DPSLTelemetryRequester: DPSLTelemetryRequester,
+};


### PR DESCRIPTION
Found problems while importing the dpsl library into the cros-diag-extension. This happens while using Jest (testing library). As outlined [here](https://jestjs.io/docs/ecmascript-modules), Jest ships with **experimental** support of ECMAScript modules.

The other advantage of using [CommonJS](https://nodejs.org/docs/latest/api/modules.html) is that it is the standard used in Node.js.

[This shouldn't affect](https://nodejs.org/api/esm.html#esm_differences_between_es_modules_and_commonjs) ES modules that import CommonJS modules.