### PR TITLE
Add missing parameter type for DiskReadRoutine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cros-dpsl-js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cros-dpsl-js",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "eslint": "^7.32.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cros-dpsl-js",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cros-dpsl-js",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cros-dpsl-js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Diagnostics processor support library for Chrome OS",
   "main": "./src/dpsl.js",
   "exports": "./src/dpsl.js",

--- a/src/diagnostics_manager.js
+++ b/src/diagnostics_manager.js
@@ -267,17 +267,18 @@ class MemoryManager {
 class DiskManager {
   /**
    * Runs disk read test.
+   * @param {!dpsl.DiskReadRoutineParams} params
    * @return { !Promise<!Routine> }
    * @public
    */
-  async runReadRoutine() {
+  async runReadRoutine(params) {
     const functionName = 'runDiskReadRoutine';
     if (!isSupported(functionName)) {
       throw new MethodNotFoundError(API_NAME, functionName,
           /* chromeVersion */ 101);
     }
 
-    return chrome.os.diagnostics.runDiskReadRoutine().then(
+    return chrome.os.diagnostics.runDiskReadRoutine(params).then(
         (response) => new Routine(response.id));
   }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -229,6 +229,16 @@ dpsl.BatteryDischargeRoutineParams;
 dpsl.CpuRoutineDurationParams;
 
 /**
+ * Params object of dpsl.diagnostics.disk.runReadRoutine()
+ * @typedef {{
+ *  type: !string,
+ *  lengthSeconds: !number,
+ *  fileSizeMb: !number
+ * }}
+ */
+ dpsl.DiskReadRoutineParams;
+
+/**
  * Params object of dpsl.diagnostics.nvme.runWearLevelRoutine()
  * @typedef {{wearLevelThreshold: !number}}
  */


### PR DESCRIPTION
In `chrome.os.diagnostics`, the DiskReadRoutine takes an parameter specifying metadata for the routine. This PR adds the corresponding parameter type.