### PR TITLE
Introduce runAcPowerRoutine

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -179,6 +179,12 @@ class Routine {
 | voltageMinDesign | number | Desired minimum output voltage |
 | voltageNow | number | Battery's voltage (V) |
 
+### AcPowerRoutineParams
+| Property Name | Type | Description |
+------------ | ------- | ----------- |
+| expectedStatus | string | The expected status of the AC ('connected', 'disconnected' or 'unknown') |
+| expectedPowerType | string | (Optional) If specified, this must match the type of power supply for the routine to succeed. |
+
 ### BatteryDischargeRoutineParams
 | Property Name | Type | Description |
 ------------ | ------- | ----------- |
@@ -215,6 +221,11 @@ class Routine {
 | Function Name | Definition |
 ------------ | ------------- |
 | getAvailableRoutines | () => Promise\<List\<string\>\> |
+
+### dpsl.diagnostics.power.*
+| Function Name | Definition |
+------------ | ------------- |
+| runAcPowerRoutine | (params: AcPowerRoutineParams) => Promise\<Routine\> |
 
 ### dpsl.diagnostics.battery.*
 | Function Name | Definition |

--- a/src/README.md
+++ b/src/README.md
@@ -183,7 +183,7 @@ class Routine {
 | Property Name | Type | Description |
 ------------ | ------- | ----------- |
 | expectedStatus | string | The expected status of the AC ('connected', 'disconnected' or 'unknown') |
-| expectedPowerType | string | (Optional) If specified, this must match the type of power supply for the routine to succeed. |
+| expectedPowerType* | string | If specified, this must match the type of power supply for the routine to succeed. |
 
 ### BatteryDischargeRoutineParams
 | Property Name | Type | Description |

--- a/src/__tests__/dpsl.test.js
+++ b/src/__tests__/dpsl.test.js
@@ -197,8 +197,9 @@ describe('dpsl.diagnostics tests', () => {
       (done) => {
         // Mock the global chrome object.
         const expectedRoutinesList = {
-          routines: ['battery_capacity', 'battery_charge', 'battery_discharge',
-            'battery_health', 'cpu_cache', 'cpu_stress', 'memory', 'disk-read',
+          routines: ['ac_power', 'battery_capacity', 'battery_charge',
+            'battery_discharge', 'battery_health', 'cpu_cache',
+            'cpu_stress', 'memory', 'disk-read',
             'smartctl-check', 'nvme-wear-level'],
         };
         const chrome = {
@@ -255,6 +256,10 @@ describe('dpsl.diagnostics tests', () => {
       });
 
   const testCases = [
+    {
+      'dpslRoutineFunction': dpsl.diagnostics.power.runAcPowerRoutine,
+      'chromeOsRoutineFunction': 'runAcPowerRoutine',
+    },
     {
       'dpslRoutineFunction': dpsl.diagnostics.battery.runCapacityRoutine,
       'chromeOsRoutineFunction': 'runBatteryCapacityRoutine',

--- a/src/diagnostics_manager.js
+++ b/src/diagnostics_manager.js
@@ -110,7 +110,7 @@ class AcPowerManager {
     const functionName = 'runAcPowerRoutine';
     if (!isSupported(functionName)) {
       throw new MethodNotFoundError(API_NAME, functionName,
-          /* chromeVersion */ 100);
+          /* chromeVersion */ 105);
     }
 
     return chrome.os.diagnostics.runAcPowerRoutine(params).then(

--- a/src/diagnostics_manager.js
+++ b/src/diagnostics_manager.js
@@ -97,6 +97,28 @@ class Routine {
 }
 
 /**
+ * AC Power Manager for dpsl.diagnostics.power.* APIs.
+ */
+class AcPowerManager {
+  /**
+   * Runs AC Power test.
+   * @param {!dpsl.AcPowerRoutineParams} params
+   * @return { !Promise<!Routine> }
+   * @public
+   */
+  async runAcPowerRoutine(params) {
+    const functionName = 'runAcPowerRoutine';
+    if (!isSupported(functionName)) {
+      throw new MethodNotFoundError(API_NAME, functionName,
+          /* chromeVersion */ 100);
+    }
+
+    return chrome.os.diagnostics.runAcPowerRoutine(params).then(
+        (response) => new Routine(response.id));
+  }
+}
+
+/**
  * Diagnostics Battery Manager for dpsl.diagnostics.battery.* APIs.
  */
 class BatteryManager {
@@ -350,6 +372,12 @@ class DPSLDiagnosticsManager {
    * @constructor
    */
   constructor() {
+    /**
+     * @type {!AcPowerManager}
+     * @public
+     */
+    this.power = new AcPowerManager();
+
     /**
      * @type {!BatteryManager}
      * @public

--- a/src/types.js
+++ b/src/types.js
@@ -204,6 +204,15 @@ dpsl.AvailableRoutinesList;
 dpsl.RoutineStatus;
 
 /**
+ * Params object of dpsl.diagnostics.power.runAcPowerRoutine()
+ * @typedef {{
+ *   expectedStatus: !string,
+ *   expectedPowerType?: string
+ * }}
+ */
+dpsl.AcPowerRoutineParams;
+
+/**
  * Params object of dpsl.diagnostics.battery.runChargeRoutine()
  * @typedef {{
  *   lengthSeconds: !number,

--- a/src/types.js
+++ b/src/types.js
@@ -207,7 +207,7 @@ dpsl.RoutineStatus;
  * Params object of dpsl.diagnostics.power.runAcPowerRoutine()
  * @typedef {{
  *   expectedStatus: !string,
- *   expectedPowerType?: string
+ *   expectedPowerType?: !string
  * }}
  */
 dpsl.AcPowerRoutineParams;


### PR DESCRIPTION
Introduce new `dpsl.diagnostics.power.runAcPowerRoutine` API
function to run the AC Power routine.