### PR TITLE
Introduce getStatefulPartitionInfo API function

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -179,6 +179,11 @@ class Routine {
 | voltageMinDesign | number | Desired minimum output voltage |
 | voltageNow | number | Battery's voltage (V) |
 
+### StatefulPartitionInfo
+| Property Name | Type | Description |
+| availableSpace | number | The currently available space in the user partition (Bytes) |
+| totalSpace | number | The total space of the user partition (Bytes) |
+
 ### AcPowerRoutineParams
 | Property Name | Type | Description |
 ------------ | ------- | ----------- |
@@ -216,6 +221,7 @@ class Routine {
 | getCpuInfo | () => Promise\<CpuInfo\> |
 | getMemoryInfo | () => Promise\<MemoryInfo\> |
 | getBatteryInfo | () => Promise\<BatteryInfo\> |
+| getStatefulPartitionInfo | () => Promise\<StatefulPartitionInfo\> |
 
 ### dpsl.diagnostics.*
 | Function Name | Definition |

--- a/src/__tests__/dpsl.test.js
+++ b/src/__tests__/dpsl.test.js
@@ -176,6 +176,30 @@ describe('dpsl.telemetry tests', () => {
       done();
     });
   });
+
+  test('dpsl.telemetry.getStatefulPartitionInfo() returns correct data',
+      (done) => {
+        // Mock the global chrome object.
+        const expectedStatefulPartitionInfo = {
+          'availableSpace': 80000000000,
+          'totalSpace': 90000000000,
+        };
+        const chrome = {
+          os: {
+            telemetry: {
+              getStatefulPartitionInfo: () => expectedStatefulPartitionInfo,
+            },
+          },
+        };
+        global.chrome = chrome;
+
+        dpsl.telemetry.getStatefulPartitionInfo()
+            .then((statefulPartitionInfo) => {
+              expect(statefulPartitionInfo)
+                  .toEqual(expectedStatefulPartitionInfo);
+              done();
+            });
+      });
 });
 
 

--- a/src/telemetry_requester.js
+++ b/src/telemetry_requester.js
@@ -105,6 +105,21 @@ class DPSLTelemetryRequester {
 
     return chrome.os.telemetry.getBatteryInfo();
   }
+
+  /**
+   * Requests Stateful Partition info.
+   * @return { !Promise<!dpsl.StatefulPartitionInfo> }
+   * @public
+   */
+  async getStatefulPartitionInfo() {
+    const functionName = 'getStatefulPartitionInfo';
+    if (!isSupported(functionName)) {
+      throw new MethodNotFoundError(API_NAME, functionName,
+          /* chromeVersion */ 105);
+    }
+
+    return chrome.os.telemetry.getStatefulPartitionInfo();
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
Introduce new `dpsl.telemetry.getStatefulPartitionInfo` API
function to fetch stateful partition info.